### PR TITLE
Fix the build task

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "eslint-config-google": "^0.9.1",
     "file-loader": "^2.0.0",
     "karmatic": "^1.2.0",
-    "microbundle": "^0.6.0",
+    "microbundle": "^0.9.0",
     "webpack": "^4.16.4"
   }
 }


### PR DESCRIPTION
Running `npm install && npm run build` was giving me the following error:

```bash
> microbundle -f umd,es && microbundle -f iife src/polyfill.mjs -o polyfill/index.js

(nodent plugin) Error: Plugin 'jsx' not found
Error: Plugin 'jsx' not found
    at Parser.loadPlugins (/Users/Karol/Projects/open-source/task-worklet/node_modules/nodent-compiler/node_modules/acorn/dist/acorn.js:543:26)
    at new Parser (/Users/Karol/Projects/open-source/task-worklet/node_modules/nodent-compiler/node_modules/acorn/dist/acorn.js:469:8)
    at Object.parse (/Users/Karol/Projects/open-source/task-worklet/node_modules/nodent-compiler/node_modules/acorn/dist/acorn.js:5288:10)
    at acornParse (/Users/Karol/Projects/open-source/task-worklet/node_modules/nodent-compiler/compiler.js:37:21)
    at NodentCompiler.parseCode [as parse] (/Users/Karol/Projects/open-source/task-worklet/node_modules/nodent-compiler/compiler.js:177:17)
    at NodentCompiler.compile (/Users/Karol/Projects/open-source/task-worklet/node_modules/nodent-compiler/compiler.js:112:19)
    at Object.transform (/Users/Karol/Projects/open-source/task-worklet/node_modules/rollup-plugin-nodent/index.js:35:25)
    at /Users/Karol/Projects/open-source/task-worklet/node_modules/rollup/dist/rollup.js:20756:41
```

After having updated `microbundle` to `^0.9.0` everything is 😌 again.